### PR TITLE
Update pubspec.yaml for fixing intl dependency issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  intl: ^0.17.0
+  intl: ^0.19.0
 
 dev_dependencies:
   test: ^1.9.4


### PR DESCRIPTION
Error - Because every version of fluent from git depends on intl ^0.17.0 and demo_app depends on intl ^0.19.0, fluent from git is forbidden.